### PR TITLE
Fix typo in SchemaWizard

### DIFF
--- a/index.md
+++ b/index.md
@@ -464,7 +464,7 @@ This is an example output from the example schema above after the user fills out
 ```javascript
 [
   {
-    fistName: 'Jane',
+    firstName: 'Jane',
     lastName: 'Doe'
   },
   {


### PR DESCRIPTION
Updated the modelValue section for SchemaWizard. The example reads `fistName` when it should read `firstName`